### PR TITLE
feature: add dockerfile to telegram-bot and docker compose to root project

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,9 @@
+version: '3.7'
+services:
+  telegram-bot:
+    build: ./telegram-bot
+    ports:
+      - "8080:8080"
+    env_file:
+      - ./telegram-bot/.env
+

--- a/telegram-bot/.dockerignore
+++ b/telegram-bot/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/telegram-bot/.gitignore
+++ b/telegram-bot/.gitignore
@@ -23,6 +23,6 @@ go.work.sum
 go.sum
 
 # Environment variables file
-.env
-.env.*
+/.env
+/.env.*
 

--- a/telegram-bot/Dockerfile
+++ b/telegram-bot/Dockerfile
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1
+
+FROM golang:1.21-alpine
+
+# Set destination for COPY
+WORKDIR /app
+
+# Download Go modules
+COPY go.mod ./
+RUN go mod download
+
+# Copy the source code. Note the slash at the end, as explained in
+# https://docs.docker.com/reference/dockerfile/#copy
+COPY . .
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux go build -o telegram-bot -v ./cmd
+
+# Optional:
+# To bind to a TCP port, runtime parameters must be supplied to the docker command.
+# But we can document in the Dockerfile what ports
+# the application is going to listen on by default.
+# https://docs.docker.com/reference/dockerfile/#expose
+EXPOSE 8080
+
+# Run
+CMD ["./telegram-bot"]

--- a/telegram-bot/cmd/main.go
+++ b/telegram-bot/cmd/main.go
@@ -17,10 +17,10 @@ func main() {
 	defer cancel()
 
 	opts := []bot.Option{
-		bot.WithDefaultHandler(handler),
+		bot.WithDefaultHandler(defaultHandler),
 	}
 
-	b, err := bot.New(os.Getenv("TELEGRAM_API_BOT"), opts...)
+	teleBot, err := bot.New(os.Getenv("TELEGRAM_API_BOT"), opts...)
 	if nil != err {
 		// panics for the sake of simplicity.
 		// you should handle this error properly in your code.
@@ -28,7 +28,7 @@ func main() {
 	}
 
 	WebHookUrl := os.Getenv("WEBHOOK_URL")
-	res, err := b.SetWebhook(ctx, &bot.SetWebhookParams{
+	res, err := teleBot.SetWebhook(ctx, &bot.SetWebhookParams{
 		URL: WebHookUrl,
 	})
 
@@ -37,7 +37,7 @@ func main() {
 	}
 
 	go func() {
-		err := http.ListenAndServe(":8080", b.WebhookHandler())
+		err := http.ListenAndServe(":8080", teleBot.WebhookHandler())
 
 		if err != nil {
 			log.Fatalf("Failed to start server")
@@ -45,12 +45,12 @@ func main() {
 	}()
 
 	// Use StartWebhook instead of Start
-	b.StartWebhook(ctx)
+	teleBot.StartWebhook(ctx)
 
 	// call methods.DeleteWebhook if needed
 }
 
-func handler(ctx context.Context, b *bot.Bot, update *models.Update) {
+func defaultHandler(ctx context.Context, b *bot.Bot, update *models.Update) {
 	_, err := b.SendMessage(ctx, &bot.SendMessageParams{
 		ChatID: update.Message.Chat.ID,
 		Text:   update.Message.Text,


### PR DESCRIPTION


Add Dockerfile to telegram-bot project to run telegram bot via Docker container and compose.yml to project root to lay groundwork for future multi-container project.